### PR TITLE
fix(notifications): fenêtre glissante 24h pour les alertes de nouvelles formations

### DIFF
--- a/services/notifications/notificationLogic.test.ts
+++ b/services/notifications/notificationLogic.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import {
-  filterTodaysFormations,
+  filterRecentFormations,
   shouldNotifyBasedOnTime,
   groupFormationsByUser,
   extractUniqueDisciplines,
-  getStartOfDay,
   UserFormationData
 } from './notificationLogic';
 import { Formation } from '@/types/formation';
 
 describe('notificationLogic', () => {
-  describe('filterTodaysFormations', () => {
-    it('should filter formations for today and specific discipline', () => {
+  describe('filterRecentFormations', () => {
+    it('should filter formations within 24h for a specific discipline', () => {
       const today = new Date('2024-01-15T10:00:00');
       const formations: Formation[] = [
         {
@@ -70,7 +69,7 @@ describe('notificationLogic', () => {
         },
       ];
 
-      const result = filterTodaysFormations(formations, 'Alpinisme', today);
+      const result = filterRecentFormations(formations, 'Alpinisme', today);
 
       expect(result).toHaveLength(1);
       expect(result[0].reference).toBe('REF1');
@@ -80,9 +79,40 @@ describe('notificationLogic', () => {
       const today = new Date('2024-01-15T10:00:00');
       const formations: Formation[] = [];
 
-      const result = filterTodaysFormations(formations, 'Alpinisme', today);
+      const result = filterRecentFormations(formations, 'Alpinisme', today);
 
       expect(result).toHaveLength(0);
+    });
+
+    it('should include a formation first seen within 24h even on the previous calendar day', () => {
+      // Régression: une formation captée par une sync hors créneau (ex: 17h58 la veille)
+      // doit rester notifiable au run de 06h00 le lendemain (< 24h), même si jour différent.
+      const now = new Date('2024-01-15T06:00:00');
+      const formations: Formation[] = [
+        {
+          reference: 'VELO1',
+          titre: 'Vélo de montagne',
+          discipline: 'Vélo-de-montagne',
+          firstSeenAt: '2024-01-14T17:58:00', // veille au soir, ~12h avant, jour calendaire précédent
+          dates: [],
+          lieu: 'Chamonix',
+          informationStagiaire: '',
+          nombreParticipants: 10,
+          placesRestantes: 5,
+          hebergement: '',
+          tarif: 100,
+          organisateur: '',
+          responsable: '',
+          emailContact: '',
+          documents: [],
+          lastSeenAt: ''
+        }
+      ];
+
+      const result = filterRecentFormations(formations, 'Vélo-de-montagne', now);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].reference).toBe('VELO1');
     });
   });
 
@@ -277,27 +307,4 @@ describe('notificationLogic', () => {
     });
   });
 
-  describe('getStartOfDay', () => {
-    it('should reset time to start of day', () => {
-      const date = new Date('2024-01-15T14:30:45.123');
-      const result = getStartOfDay(date);
-
-      expect(result.getFullYear()).toBe(2024);
-      expect(result.getMonth()).toBe(0); // January
-      expect(result.getDate()).toBe(15);
-      expect(result.getHours()).toBe(0);
-      expect(result.getMinutes()).toBe(0);
-      expect(result.getSeconds()).toBe(0);
-      expect(result.getMilliseconds()).toBe(0);
-    });
-
-    it('should not modify the original date', () => {
-      const originalDate = new Date('2024-01-15T14:30:45.123');
-      const originalTime = originalDate.getTime();
-
-      getStartOfDay(originalDate);
-
-      expect(originalDate.getTime()).toBe(originalTime);
-    });
-  });
 });

--- a/services/notifications/notificationLogic.ts
+++ b/services/notifications/notificationLogic.ts
@@ -1,23 +1,31 @@
 import { Formation } from "@/types/formation";
-import { isSameDay } from "date-fns";
 
 /**
  * Fonctions pures pour la logique de notification
  * Séparées pour faciliter les tests unitaires
  */
 
+export const NOTIFICATION_WINDOW_HOURS = 24;
+
 /**
- * Filtre les formations du jour pour une discipline donnée
+ * Filtre les formations récemment apparues pour une discipline donnée.
+ *
+ * Fenêtre glissante sur `first_seen_at` (24h par défaut) plutôt que « même jour
+ * calendaire » : une formation captée par une sync hors créneau (ex: en soirée)
+ * reste notifiable au run suivant. Le throttle par utilisateur (last_notified_at)
+ * évite les doublons.
  */
-export const filterTodaysFormations = (
+export const filterRecentFormations = (
   formations: Formation[],
   discipline: string,
-  today: Date
+  now: Date,
+  windowHours: number = NOTIFICATION_WINDOW_HOURS
 ): Formation[] => {
+  const cutoff = now.getTime() - windowHours * 60 * 60 * 1000;
   return formations.filter(f =>
     f.discipline === discipline &&
     f.firstSeenAt &&
-    isSameDay(new Date(f.firstSeenAt), today)
+    new Date(f.firstSeenAt).getTime() >= cutoff
   );
 };
 
@@ -72,13 +80,4 @@ export const groupFormationsByUser = (
  */
 export const extractUniqueDisciplines = (formations: Formation[]): string[] => {
   return [...new Set(formations.map(f => f.discipline))];
-};
-
-/**
- * Prépare une date pour la comparaison (début de journée)
- */
-export const getStartOfDay = (date: Date): Date => {
-  const newDate = new Date(date);
-  newDate.setHours(0, 0, 0, 0);
-  return newDate;
 };

--- a/services/notifications/notificationProcessor.service.ts
+++ b/services/notifications/notificationProcessor.service.ts
@@ -3,12 +3,9 @@ import { Formation } from "@/types/formation";
 import { UserService } from "@/services/user/users.service";
 import { UserRepository } from "@/repositories/UserRepository";
 import {
-  filterTodaysFormations,
+  filterRecentFormations,
   shouldNotifyBasedOnTime,
-  groupFormationsByUser,
-  extractUniqueDisciplines,
-  getStartOfDay,
-  UserFormationData
+  extractUniqueDisciplines
 } from "./notificationLogic";
 
 // Ces instances globales seront progressivement supprimées
@@ -63,22 +60,20 @@ export interface UserNotificationData {
     ): Promise<void> {
       const usersToNotify = await this.actualUserService.getUsersToNotifyForDiscipline(discipline);
 
-      const today = getStartOfDay(this.dateProvider());
+      // Fenêtre glissante sur first_seen_at (robuste aux syncs hors créneau)
+      const recentFormations = filterRecentFormations(formations, discipline, this.dateProvider());
 
-      // Utilise la fonction pure pour filtrer
-      const todaysFormations = filterTodaysFormations(formations, discipline, today);
-    
-      // Si aucune formation du jour, on peut éviter de traiter les utilisateurs
-      if (todaysFormations.length === 0) {
+      // Si aucune formation récente, on peut éviter de traiter les utilisateurs
+      if (recentFormations.length === 0) {
         return;
       }
-    
+
       for (const {userId, email} of usersToNotify) {
         if (await this.shouldNotifyUser(userId, discipline)) {
           this.addFormationsForUser(
             userId,
             email,
-            todaysFormations,
+            recentFormations,
             userNotifications
           );
         }

--- a/services/notifications/notificationProcessor.service.ts
+++ b/services/notifications/notificationProcessor.service.ts
@@ -58,15 +58,15 @@ export interface UserNotificationData {
       formations: Formation[],
       userNotifications: Map<string, UserNotificationData>
     ): Promise<void> {
-      const usersToNotify = await this.actualUserService.getUsersToNotifyForDiscipline(discipline);
-
       // Fenêtre glissante sur first_seen_at (robuste aux syncs hors créneau)
       const recentFormations = filterRecentFormations(formations, discipline, this.dateProvider());
 
-      // Si aucune formation récente, on peut éviter de traiter les utilisateurs
+      // Si aucune formation récente, on évite la requête de récupération des utilisateurs
       if (recentFormations.length === 0) {
         return;
       }
+
+      const usersToNotify = await this.actualUserService.getUsersToNotifyForDiscipline(discipline);
 
       for (const {userId, email} of usersToNotify) {
         if (await this.shouldNotifyUser(userId, discipline)) {

--- a/services/notifications/notificationProcessor.test.ts
+++ b/services/notifications/notificationProcessor.test.ts
@@ -112,16 +112,16 @@ describe('NotificationProcessor avec injection', () => {
       expect(result.size).toBe(0);
     });
 
-    it('should filter out formations from other days', async () => {
-      const yesterday = new Date(fixedDate);
-      yesterday.setDate(yesterday.getDate() - 1);
+    it('should filter out formations older than the 24h window', async () => {
+      const threeDaysAgo = new Date(fixedDate);
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
       const formations: Formation[] = [
         {
           reference: 'REF1',
-          titre: 'Formation Hier',
+          titre: 'Formation ancienne',
           discipline: 'Alpinisme',
-          firstSeenAt: yesterday.toISOString(), // Hier
+          firstSeenAt: threeDaysAgo.toISOString(), // au-delà de 24h
           dates: [],
           lieu: 'Chamonix',
           informationStagiaire: '',
@@ -145,10 +145,49 @@ describe('NotificationProcessor avec injection', () => {
 
       const result = await processor.processFormations(formations);
 
-      // Aucun utilisateur ne doit être notifié car pas de formations du jour
+      // Aucun utilisateur ne doit être notifié car la formation est trop ancienne
       expect(result.size).toBe(0);
-      // getUsersToNotifyForDiscipline ne devrait même pas être appelé si aucune formation du jour
       expect(mockUserService.getUsersToNotifyForDiscipline).toHaveBeenCalled();
+    });
+
+    it('should notify for a formation first seen within 24h on the previous calendar day', async () => {
+      // Régression: sync hors créneau (la veille au soir). La formation est < 24h
+      // au moment du run mais sur un jour calendaire différent -> doit être notifiée.
+      const yesterdayEvening = new Date(fixedDate);
+      yesterdayEvening.setHours(yesterdayEvening.getHours() - 16); // ~16h avant, jour précédent
+
+      const formations: Formation[] = [
+        {
+          reference: 'VELO1',
+          titre: 'Vélo de montagne',
+          discipline: 'Vélo-de-montagne',
+          firstSeenAt: yesterdayEvening.toISOString(),
+          dates: [],
+          lieu: 'Chamonix',
+          informationStagiaire: '',
+          nombreParticipants: 10,
+          placesRestantes: 5,
+          hebergement: '',
+          tarif: 100,
+          organisateur: '',
+          responsable: '',
+          emailContact: '',
+          documents: [],
+          lastSeenAt: ''
+        }
+      ];
+
+      mockUserService.getUsersToNotifyForDiscipline.mockResolvedValue([
+        { userId: 'user1', email: 'user1@test.com' }
+      ]);
+
+      mockNotificationRepo.getLastNotification.mockResolvedValue(null);
+
+      const result = await processor.processFormations(formations);
+
+      expect(result.size).toBe(1);
+      expect(result.get('user1')?.formations).toHaveLength(1);
+      expect(result.get('user1')?.formations[0].reference).toBe('VELO1');
     });
 
     it('should handle multiple disciplines correctly', async () => {

--- a/services/notifications/notificationProcessor.test.ts
+++ b/services/notifications/notificationProcessor.test.ts
@@ -147,7 +147,8 @@ describe('NotificationProcessor avec injection', () => {
 
       // Aucun utilisateur ne doit être notifié car la formation est trop ancienne
       expect(result.size).toBe(0);
-      expect(mockUserService.getUsersToNotifyForDiscipline).toHaveBeenCalled();
+      // La fenêtre étant vide, on n'interroge même pas les utilisateurs
+      expect(mockUserService.getUsersToNotifyForDiscipline).not.toHaveBeenCalled();
     });
 
     it('should notify for a formation first seen within 24h on the previous calendar day', async () => {


### PR DESCRIPTION
## Problème

Les abonnés ne recevaient plus d'alerte pour leur discipline (reproduit sur « Vélo-de-montagne » : 43 abonnés, dont plusieurs avec `last_notified_at = null`, jamais notifiés).

**Cause racine** (confirmée sur la base de prod) : `filterTodaysFormations` n'incluait une formation que si son `first_seen_at` tombait **le même jour calendaire** que le cron de notifications (06:00). Le sync étant à 04:00, seules les formations vues entre 00:00 et 06:00 étaient notifiables. Les 2 dernières formations « Vélo-de-montagne » ont été captées par une **sync hors créneau (20 mai à 17:58)** → au run du lendemain 06:00, `isSameDay` les voyait comme « hier » → jamais notifiées à personne.

Ce n'était pas un problème de fragmentation des disciplines : abonnés et formations sont sur le même id (252).

## Changements

- Remplacement du filtre `isSameDay(first_seen_at, today)` par une **fenêtre glissante de 24h** sur `first_seen_at` (`filterTodaysFormations` → `filterRecentFormations`, constante `NOTIFICATION_WINDOW_HOURS`).
- Le throttle existant par utilisateur/discipline (`last_notified_at > 24h`) continue d'éviter les doublons.
- Suppression du helper `getStartOfDay` (devenu inutile) et d'imports morts pré-existants dans le processor.
- Tests mis à jour + **test de régression** : une formation vue la veille au soir (<24h, jour calendaire différent) doit être notifiée.

Conséquence voulue : les nouveautés captées hors créneau (sync manuelle, sync en retard, jour de cron raté) sont désormais rattrapées au run suivant.

## Hors périmètre

Pas de rattrapage des formations déjà manquées (les 2 du 20 mai ont maintenant >24h). Les changements UI en cours dans le working tree ne sont pas inclus dans cette PR.

## Test plan

- [x] `vitest run services/notifications/` — 21/21 verts
- [x] Suite complète — 108 tests verts
- [x] Test de régression rouge **avant** le fix, vert **après**
- [x] `pnpm lint` + `pnpm build` (pre-push) OK
- [ ] Vérifier en prod au prochain cron 06:00 qu'une nouvelle formation hors créneau déclenche bien l'email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now use a 24-hour rolling window instead of calendar-day boundaries, so detections within the past 24 hours are consistently notified even if they occurred on the previous calendar day.

* **Tests**
  * Time-window and edge-case tests updated to cover the 24-hour sliding-window behavior and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ffcam-aura/ffcam-formations/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->