### PR TITLE
feat(notifications): alerte anti-récidive + retry cron

### DIFF
--- a/app/api/notifications/send/route.ts
+++ b/app/api/notifications/send/route.ts
@@ -107,12 +107,18 @@ async function buildReconciliation(
 
   const reconciliation: DisciplineReconciliation[] = [];
   for (const { discipline, count } of newByDiscipline) {
+    // NOTE angle mort : on réutilise ici la requête de production
+    // `getUsersToNotifyForDiscipline` (côté abonnés). Si un futur bug s'introduit
+    // dans CETTE requête (ex. clause OR inversée, filtre `enabled` qui régresse),
+    // les deux côtés tomberaient à 0 et l'anomalie ne se lèverait pas. Le
+    // monitoring est donc indépendant du filtre `first_seen_at` (côté formations)
+    // mais pas du filtre d'abonnés. À renforcer si on a un incident sur ce chemin.
     const notifiable = await userService.getUsersToNotifyForDiscipline(discipline);
     reconciliation.push({
       discipline,
       newFormations: count,
       notifiableSubscribers: notifiable.length,
-      notified: notifiedByDiscipline.get(discipline) ?? 0
+      notificationsSent: notifiedByDiscipline.get(discipline) ?? 0
     });
   }
   return reconciliation;
@@ -123,6 +129,15 @@ interface NotificationStats {
   notifiedUsers: number;
   errors: number;
   formationsWithNotifications: number;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 async function sendHealthcheckEmail(
@@ -147,7 +162,7 @@ async function sendHealthcheckEmail(
           <p style="color: #dc2626; font-weight: bold; margin: 0 0 8px;">⚠️ Formations nouvelles non notifiées</p>
           <p style="margin: 0 0 8px;">Des formations récentes existent dans des disciplines ayant des abonnés disponibles, mais aucune notification n'a été envoyée. Vérifier le pipeline de notification.</p>
           <ul>
-            ${missed.map(m => `<li><strong>${m.discipline}</strong> : ${m.newFormations} formation(s) récente(s), ${m.notifiableSubscribers} abonné(s) en attente, 0 notifié</li>`).join('')}
+            ${missed.map(m => `<li><strong>${escapeHtml(m.discipline)}</strong> : ${m.newFormations} formation(s) récente(s), ${m.notifiableSubscribers} abonné(s) en attente, 0 notifié</li>`).join('')}
           </ul>
         </div>
       `

--- a/app/api/notifications/send/route.ts
+++ b/app/api/notifications/send/route.ts
@@ -6,12 +6,21 @@ import { FormationService } from "@/services/formation/formations.service";
 import { NotificationService } from "@/services/notifications/notifications.service";
 import { UserService } from "@/services/user/users.service";
 import { FormationRepository } from "@/repositories/FormationRepository";
+import { UserRepository } from "@/repositories/UserRepository";
+import {
+  NOTIFICATION_WINDOW_HOURS,
+  findUnnotifiedDisciplines,
+  DisciplineReconciliation
+} from "@/services/notifications/notificationLogic";
 import { logger } from "@/lib/logger";
 import { validateCronSecret, unauthorizedResponse } from "@/lib/auth";
 import { env } from "@/env";
 
 const formationRepository = new FormationRepository();
 const formationService = new FormationService(formationRepository);
+const userService = new UserService(new UserRepository());
+
+type NotificationResult = Awaited<ReturnType<NotificationService["notifyBatchNewFormations"]>>[number];
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
@@ -31,26 +40,24 @@ export async function GET(request: Request) {
   try {
     // Récupère les formations des dernières 24h
     logger.info('Fetching recent formations...');
-    const recentFormations = await formationService.getRecentFormations(24);
+    const recentFormations = await formationService.getRecentFormations(NOTIFICATION_WINDOW_HOURS);
     logger.info(`Found ${recentFormations.length} recent formations`);
 
-    if (recentFormations.length === 0) {
-      // Still send healthcheck to confirm email system works
-      logger.info('No formations, sending healthcheck email...');
-      await sendHealthcheckEmail({ totalFormations: 0, notifiedUsers: 0, errors: 0, formationsWithNotifications: 0 });
-
-      return Response.json({
-        success: true,
-        message: 'No recent formations to notify about',
-        notified: 0
-      });
+    // Envoie les notifications (le cas "0 formation" est géré naturellement : aucun envoi)
+    let notificationResults: NotificationResult[] = [];
+    if (recentFormations.length > 0) {
+      logger.info('Sending notifications...');
+      notificationResults = await notificationService.notifyBatchNewFormations(recentFormations);
     }
 
-    // Envoie les notifications
-    logger.info('Sending notifications...');
-    const notificationResults = await notificationService.notifyBatchNewFormations(recentFormations);
+    // Réconciliation INDÉPENDANTE du filtre de notification : détecte un échec
+    // silencieux (formations nouvelles + abonnés disponibles, mais 0 notifié).
+    const reconciliation = await buildReconciliation(notificationResults);
+    const missed = findUnnotifiedDisciplines(reconciliation);
+    if (missed.length > 0) {
+      logger.warn('Anomalie notifications: formations nouvelles non notifiées', { missed });
+    }
 
-    // Calcule les statistiques de notification
     const stats = {
       totalFormations: recentFormations.length,
       notifiedUsers: notificationResults.reduce((acc, result) => acc + result.usersNotified, 0),
@@ -58,14 +65,17 @@ export async function GET(request: Request) {
       formationsWithNotifications: notificationResults.filter(r => r.usersNotified > 0).length
     };
 
-    // Send healthcheck email (tests full email delivery chain)
-    logger.info('Sending healthcheck email...', { stats });
-    await sendHealthcheckEmail(stats);
+    // Healthcheck (dead man's switch) + alerte sur anomalie
+    logger.info('Sending healthcheck email...', { stats, missed: missed.length });
+    await sendHealthcheckEmail(stats, missed);
 
     return Response.json({
       success: true,
-      message: `Notifications sent for ${stats.totalFormations} formations`,
-      stats
+      message: missed.length > 0
+        ? `ALERTE: ${missed.length} discipline(s) avec formations non notifiées`
+        : `Notifications sent for ${stats.totalFormations} formations`,
+      stats,
+      missed
     });
 
   } catch (error) {
@@ -80,6 +90,34 @@ export async function GET(request: Request) {
   }
 }
 
+/**
+ * Construit la réconciliation par discipline à partir d'une requête `first_seen_at`
+ * indépendante et des notifications réellement envoyées par ce run.
+ */
+async function buildReconciliation(
+  notificationResults: NotificationResult[]
+): Promise<DisciplineReconciliation[]> {
+  const newByDiscipline = await formationService.getNewFormationCountsByDiscipline(NOTIFICATION_WINDOW_HOURS);
+
+  const notifiedByDiscipline = new Map<string, number>();
+  for (const result of notificationResults) {
+    const discipline = result.formation.discipline;
+    notifiedByDiscipline.set(discipline, (notifiedByDiscipline.get(discipline) ?? 0) + result.usersNotified);
+  }
+
+  const reconciliation: DisciplineReconciliation[] = [];
+  for (const { discipline, count } of newByDiscipline) {
+    const notifiable = await userService.getUsersToNotifyForDiscipline(discipline);
+    reconciliation.push({
+      discipline,
+      newFormations: count,
+      notifiableSubscribers: notifiable.length,
+      notified: notifiedByDiscipline.get(discipline) ?? 0
+    });
+  }
+  return reconciliation;
+}
+
 interface NotificationStats {
   totalFormations: number;
   notifiedUsers: number;
@@ -87,21 +125,40 @@ interface NotificationStats {
   formationsWithNotifications: number;
 }
 
-async function sendHealthcheckEmail(stats: NotificationStats): Promise<void> {
+async function sendHealthcheckEmail(
+  stats: NotificationStats,
+  missed: DisciplineReconciliation[] = []
+): Promise<void> {
   const healthcheckEmail = env.HEALTHCHECK_NOTIFICATIONS_EMAIL;
   if (!healthcheckEmail) {
     logger.info('Healthcheck email not configured, skipping');
     return;
   }
 
-  const status = stats.errors === 0 ? '✅' : '⚠️';
-  const subject = `${status} FFCAM Notifications - ${stats.notifiedUsers} users, ${stats.totalFormations} formations`;
+  const hasAnomaly = missed.length > 0;
+  const status = stats.errors === 0 && !hasAnomaly ? '✅' : '⚠️';
+  const subject = hasAnomaly
+    ? `⚠️ FFCAM ALERTE - ${missed.length} discipline(s) avec formations non notifiées`
+    : `${status} FFCAM Notifications - ${stats.notifiedUsers} users, ${stats.totalFormations} formations`;
+
+  const alertSection = hasAnomaly
+    ? `
+        <div style="border: 2px solid #dc2626; border-radius: 8px; padding: 12px; margin-bottom: 16px;">
+          <p style="color: #dc2626; font-weight: bold; margin: 0 0 8px;">⚠️ Formations nouvelles non notifiées</p>
+          <p style="margin: 0 0 8px;">Des formations récentes existent dans des disciplines ayant des abonnés disponibles, mais aucune notification n'a été envoyée. Vérifier le pipeline de notification.</p>
+          <ul>
+            ${missed.map(m => `<li><strong>${m.discipline}</strong> : ${m.newFormations} formation(s) récente(s), ${m.notifiableSubscribers} abonné(s) en attente, 0 notifié</li>`).join('')}
+          </ul>
+        </div>
+      `
+    : '';
 
   try {
     await EmailService.sendEmail({
       to: healthcheckEmail,
       subject,
       html: `
+        ${alertSection}
         <p><strong>Notifications FFCAM</strong></p>
         <ul>
           <li>Formations récentes: ${stats.totalFormations}</li>
@@ -111,7 +168,7 @@ async function sendHealthcheckEmail(stats: NotificationStats): Promise<void> {
         <p><em>Cet email confirme que le système d'envoi fonctionne.</em></p>
       `
     });
-    logger.info('Healthcheck email sent', { to: healthcheckEmail });
+    logger.info('Healthcheck email sent', { to: healthcheckEmail, hasAnomaly });
   } catch (error) {
     // Log but don't throw - healthcheck failure shouldn't break the response
     logger.warn('Failed to send healthcheck email', {

--- a/repositories/FormationRepository.ts
+++ b/repositories/FormationRepository.ts
@@ -12,6 +12,7 @@ export interface IFormationRepository {
     findAllFormations(): Promise<Formation[]>;
     findAllDisciplines(): Promise<string[]>;
     findRecentFormations(hours: number): Promise<Formation[]>;
+    findNewFormationsByDiscipline(since: Date): Promise<Array<{ discipline: string; count: number }>>;
     getLastSync(): Promise<Date | null>;
 }
 
@@ -284,6 +285,30 @@ export class FormationRepository implements IFormationRepository {
         });
 
         return formations.map(this.mapFormationToDTO);
+    }
+
+    /**
+     * Compte les formations réellement nouvelles (first_seen_at >= since) par discipline.
+     * Indépendant du filtre de notification : sert au monitoring de réconciliation.
+     */
+    async findNewFormationsByDiscipline(since: Date): Promise<Array<{ discipline: string; count: number }>> {
+        const rows = await prisma.formations.findMany({
+            where: {
+                status: 'active',
+                first_seen_at: { gte: since }
+            },
+            select: {
+                disciplines: { select: { nom: true } }
+            }
+        });
+
+        const counts = new Map<string, number>();
+        for (const row of rows) {
+            const nom = row.disciplines?.nom;
+            if (!nom) continue;
+            counts.set(nom, (counts.get(nom) ?? 0) + 1);
+        }
+        return Array.from(counts, ([discipline, count]) => ({ discipline, count }));
     }
 
     private mapFormationToDTO(formation: any): Formation {

--- a/services/formation/formations.service.ts
+++ b/services/formation/formations.service.ts
@@ -123,6 +123,21 @@ export class FormationService {
     }
 
     /**
+     * Compte les formations réellement nouvelles (first_seen_at) par discipline.
+     * Indépendant du filtre de notification : alimente le monitoring de réconciliation.
+     * @param hours Fenêtre de fraîcheur en heures
+     */
+    async getNewFormationCountsByDiscipline(hours: number): Promise<Array<{ discipline: string; count: number }>> {
+        try {
+            const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+            return await this.formationRepository.findNewFormationsByDiscipline(since);
+        } catch (error) {
+            logger.error('Error counting new formations by discipline', error as Error, { hours });
+            throw error;
+        }
+    }
+
+    /**
      * Vérifie si une formation existe déjà
      */
     async isFormationExists(reference: string): Promise<boolean> {

--- a/services/notifications/notificationLogic.test.ts
+++ b/services/notifications/notificationLogic.test.ts
@@ -314,7 +314,7 @@ describe('notificationLogic', () => {
       discipline: 'Vélo-de-montagne',
       newFormations: 2,
       notifiableSubscribers: 5,
-      notified: 0,
+      notificationsSent: 0,
       ...over
     });
 
@@ -326,7 +326,7 @@ describe('notificationLogic', () => {
     });
 
     it('does not flag when notifications were sent', () => {
-      const result = findUnnotifiedDisciplines([rec({ notified: 3 })]);
+      const result = findUnnotifiedDisciplines([rec({ notificationsSent: 3 })]);
 
       expect(result).toHaveLength(0);
     });
@@ -347,8 +347,8 @@ describe('notificationLogic', () => {
     it('returns only the disciplines that are actually broken', () => {
       const result = findUnnotifiedDisciplines([
         rec({ discipline: 'Vélo-de-montagne' }),
-        rec({ discipline: 'Alpinisme', notified: 4 }),
-        rec({ discipline: 'Escalade', newFormations: 1, notified: 0 })
+        rec({ discipline: 'Alpinisme', notificationsSent: 4 }),
+        rec({ discipline: 'Escalade', newFormations: 1, notificationsSent: 0 })
       ]);
 
       expect(result.map(r => r.discipline)).toEqual(['Vélo-de-montagne', 'Escalade']);

--- a/services/notifications/notificationLogic.test.ts
+++ b/services/notifications/notificationLogic.test.ts
@@ -4,6 +4,8 @@ import {
   shouldNotifyBasedOnTime,
   groupFormationsByUser,
   extractUniqueDisciplines,
+  findUnnotifiedDisciplines,
+  DisciplineReconciliation,
   UserFormationData
 } from './notificationLogic';
 import { Formation } from '@/types/formation';
@@ -304,6 +306,52 @@ describe('notificationLogic', () => {
       expect(result).toHaveLength(2);
       expect(result).toContain('Alpinisme');
       expect(result).toContain('Escalade');
+    });
+  });
+
+  describe('findUnnotifiedDisciplines', () => {
+    const rec = (over: Partial<DisciplineReconciliation>): DisciplineReconciliation => ({
+      discipline: 'Vélo-de-montagne',
+      newFormations: 2,
+      notifiableSubscribers: 5,
+      notified: 0,
+      ...over
+    });
+
+    it('flags a discipline with new formations and available subscribers but nobody notified', () => {
+      const result = findUnnotifiedDisciplines([rec({})]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].discipline).toBe('Vélo-de-montagne');
+    });
+
+    it('does not flag when notifications were sent', () => {
+      const result = findUnnotifiedDisciplines([rec({ notified: 3 })]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not flag when all subscribers are throttled (none available)', () => {
+      // notifiableSubscribers exclut déjà les abonnés throttlés : 0 disponible = pas une anomalie
+      const result = findUnnotifiedDisciplines([rec({ notifiableSubscribers: 0 })]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not flag when there are no new formations', () => {
+      const result = findUnnotifiedDisciplines([rec({ newFormations: 0 })]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns only the disciplines that are actually broken', () => {
+      const result = findUnnotifiedDisciplines([
+        rec({ discipline: 'Vélo-de-montagne' }),
+        rec({ discipline: 'Alpinisme', notified: 4 }),
+        rec({ discipline: 'Escalade', newFormations: 1, notified: 0 })
+      ]);
+
+      expect(result.map(r => r.discipline)).toEqual(['Vélo-de-montagne', 'Escalade']);
     });
   });
 

--- a/services/notifications/notificationLogic.ts
+++ b/services/notifications/notificationLogic.ts
@@ -92,7 +92,8 @@ export interface DisciplineReconciliation {
   discipline: string;
   newFormations: number;
   notifiableSubscribers: number;
-  notified: number;
+  /** Nombre d'événements (formation × user) notifiés, pas le nombre d'utilisateurs distincts. */
+  notificationsSent: number;
 }
 
 /**
@@ -104,5 +105,6 @@ export const findUnnotifiedDisciplines = (
   reconciliations: DisciplineReconciliation[]
 ): DisciplineReconciliation[] =>
   reconciliations.filter(
-    r => r.newFormations > 0 && r.notifiableSubscribers > 0 && r.notified === 0
+    r => r.newFormations > 0 && r.notifiableSubscribers > 0 && r.notificationsSent === 0
   );
+

--- a/services/notifications/notificationLogic.ts
+++ b/services/notifications/notificationLogic.ts
@@ -81,3 +81,28 @@ export const groupFormationsByUser = (
 export const extractUniqueDisciplines = (formations: Formation[]): string[] => {
   return [...new Set(formations.map(f => f.discipline))];
 };
+
+/**
+ * Réconciliation, par discipline, entre ce qui aurait dû être notifié et ce qui l'a été.
+ *
+ * `newFormations` provient d'une requête indépendante sur `first_seen_at` (PAS du
+ * filtre de notification), afin de pouvoir détecter un futur bug DANS ce filtre.
+ */
+export interface DisciplineReconciliation {
+  discipline: string;
+  newFormations: number;
+  notifiableSubscribers: number;
+  notified: number;
+}
+
+/**
+ * Détecte les échecs silencieux : des formations nouvelles existent dans une
+ * discipline qui a des abonnés disponibles (hors throttle 24h), mais personne
+ * n'a été notifié. C'est la signature exacte du bug de notifications.
+ */
+export const findUnnotifiedDisciplines = (
+  reconciliations: DisciplineReconciliation[]
+): DisciplineReconciliation[] =>
+  reconciliations.filter(
+    r => r.newFormations > 0 && r.notifiableSubscribers > 0 && r.notified === 0
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,9 @@
     {
       "path": "/api/notifications/send",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/notifications/send",
+      "schedule": "0 8 * * *"
     }]
   }


### PR DESCRIPTION
## Summary

Deux protections complémentaires contre les pannes du pipeline de notifications, déclenchées par deux incidents distincts (bug VDM du 20/05 + 500 transitoire du 30/05 matin).

- **Alerte sur échec silencieux** — réconciliation \`first_seen_at\` *indépendante* du filtre de notification (donc résistante à un futur bug DANS ce filtre), email ⚠️ sur le canal healthcheck existant quand formations nouvelles + abonnés disponibles + 0 notifié.
- **Cron de retry** à 08:00 UTC (~2h après le run principal). Évite l'intervention manuelle en cas de transient ; l'alerte DOWN initiale reste levée (on reste informé), seul le rétablissement est automatisé. Throttle 24h ⇒ pas de double-notif.

## Détail

### Détection d'anomalie (silent-success)
- \`notificationLogic.ts\` : \`DisciplineReconciliation\` + \`findUnnotifiedDisciplines\` (pure, testée).
- \`FormationRepository.findNewFormationsByDiscipline(since)\` : requête \`first_seen_at\` indépendante du chemin notif.
- \`FormationService.getNewFormationCountsByDiscipline(hours)\` : wrapper.
- Route \`/api/notifications/send\` : exécute la réconciliation après l'envoi, log un \`warn\` si anomalie, et le healthcheck devient \`⚠️ FFCAM ALERTE …\` avec détail par discipline. Anti-fausse-alerte : les abonnés throttlés ne comptent pas comme « en attente », donc « tout le monde déjà notifié » n'alerte pas.

### Retry cron
- \`vercel.json\` : 2e schedule \`0 8 * * *\` sur \`/api/notifications/send\`.
- Choix du timing : laisse l'alerte DOWN se lever (~07:00 UTC) avant que le retry tourne, donc tu apprends qu'il y a eu un transient, puis l'UP arrive ~1h après.

## Tests

- 113 tests passent (+5 nouveaux sur \`findUnnotifiedDisciplines\`).
- Build OK (pre-push hook validé).
- Lint OK (warnings pré-existants uniquement).

## Test plan

- [ ] Merger.
- [ ] Déployer sur le remote \`vercel\` (\`git push vercel origin/main:main\` ou équivalent).
- [ ] Surveiller le run du \`0 8 * * *\` demain et confirmer qu'un healthcheck \`✅\` ou \`⚠️\` arrive bien.
- [ ] (optionnel) Provoquer une fausse anomalie (ajout manuel d'une formation test) pour vérifier que l'email \`⚠️ FFCAM ALERTE …\` arrive avec le bon contenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and reports "missed" disciplines (new formations with no notifications) and includes anomalies in healthcheck emails; API responses now always return run stats and missed details.
* **Improvements**
  * Added a second daily notification run and enhanced run statistics and logging (includes anomaly flag).
* **Tests**
  * Added tests covering discipline reconciliation and missed-notification detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ffcam-aura/ffcam-formations/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Suite au code review (commit `adab2ae`)

- Renommage `notified` → `notificationsSent` sur `DisciplineReconciliation` (le compteur représente des événements formation × user, pas des utilisateurs distincts ; le check `=== 0` reste équivalent).
- Commentaire explicite sur **l'angle mort symétrique** : la réconciliation est indépendante du filtre `first_seen_at` (côté formations) mais réutilise `getUsersToNotifyForDiscipline` (côté abonnés). À renforcer si un incident touche cette requête.
- `escapeHtml()` pour les noms de discipline injectés dans l'email d'alerte.
- Trailing newlines.

## Note opérationnelle — Healthchecks.io

Avec le retry cron, le canal reçoit **2 pings/jour** (06h00 et 08h00 UTC) au lieu de 1. Healthchecks.io reset son grace window au dernier ping reçu : sur un futur jour où le 06h échoue ET le 08h échoue aussi, le DOWN se lèvera ~2h plus tard qu'avant. Latence de détection acceptable vu que c'est un backstop, pas l'alerte primaire.
