### PR TITLE
feat(formation): rendre les URLs cliquables dans les infos stagiaires

### DIFF
--- a/app/formation/[slug]/page.tsx
+++ b/app/formation/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import ObfuscatedEmail from '@/components/features/formations/ObfuscatedEmail';
 import ObfuscatedInscriptionButton from '@/components/features/formations/ObfuscatedInscriptionButton';
+import Linkify from '@/components/ui/Linkify';
 import { formatDate, formatFullDateRange } from '@/utils/dateUtils';
 import { logger } from '@/lib/logger';
 
@@ -236,7 +237,7 @@ export default async function FormationPage({ params }: PageProps) {
                 </CardHeader>
                 <CardContent>
                   <p className="text-gray-700 whitespace-pre-wrap">
-                    {formation.informationStagiaire}
+                    <Linkify text={formation.informationStagiaire} />
                   </p>
                 </CardContent>
               </Card>

--- a/components/ui/Linkify.test.tsx
+++ b/components/ui/Linkify.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Linkify from './Linkify';
+
+describe('Linkify', () => {
+  it('transforme une URL https en lien cliquable', () => {
+    render(<Linkify text="Voir https://ffcam.fr/programme pour le détail" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://ffcam.fr/programme');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('préfixe les adresses en www. avec https://', () => {
+    render(<Linkify text="Plus d'infos sur www.ffcam.fr" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://www.ffcam.fr');
+    expect(link).toHaveTextContent('www.ffcam.fr');
+  });
+
+  it("exclut la ponctuation finale collée à l'URL", () => {
+    render(<Linkify text="Détails ici : https://ffcam.fr/page." />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://ffcam.fr/page');
+    expect(link).toHaveTextContent('https://ffcam.fr/page');
+  });
+
+  it('gère plusieurs URLs dans le même texte', () => {
+    render(
+      <Linkify text="Voir https://a.fr et aussi https://b.fr merci" />
+    );
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', 'https://a.fr');
+    expect(links[1]).toHaveAttribute('href', 'https://b.fr');
+  });
+
+  it('ne crée aucun lien quand il n\'y a pas d\'URL', () => {
+    render(<Linkify text="Apporter chaussures et casque." />);
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('ne transforme pas une URL javascript: (sécurité)', () => {
+    render(<Linkify text="javascript:alert(1)" />);
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('conserve le texte autour des liens', () => {
+    const { container } = render(
+      <Linkify text="Avant https://ffcam.fr après" />
+    );
+    expect(container.textContent).toBe('Avant https://ffcam.fr après');
+  });
+});

--- a/components/ui/Linkify.tsx
+++ b/components/ui/Linkify.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+// Détecte les URLs http(s) et les adresses commençant par www.
+const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+|www\.[^\s]+)/gi;
+const URL_TEST_REGEX = /^(https?:\/\/|www\.)/i;
+
+// Retire la ponctuation de fin souvent collée à une URL dans du texte libre
+function splitTrailingPunctuation(url: string): [string, string] {
+  const match = url.match(/[).,;:!?]+$/);
+  if (!match) {
+    return [url, ''];
+  }
+  const trailing = match[0];
+  return [url.slice(0, url.length - trailing.length), trailing];
+}
+
+interface LinkifyProps {
+  text: string;
+}
+
+/**
+ * Affiche un texte en transformant les URLs qu'il contient en liens cliquables.
+ */
+export default function Linkify({ text }: LinkifyProps) {
+  const parts = text.split(URL_SPLIT_REGEX);
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (!part) {
+          return null;
+        }
+
+        if (URL_TEST_REGEX.test(part)) {
+          const [url, trailing] = splitTrailingPunctuation(part);
+          const href = url.startsWith('http') ? url : `https://${url}`;
+
+          return (
+            <React.Fragment key={index}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary-600 hover:text-primary-700 underline break-words"
+              >
+                {url}
+              </a>
+              {trailing}
+            </React.Fragment>
+          );
+        }
+
+        return <React.Fragment key={index}>{part}</React.Fragment>;
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
## Contexte

Dans la page de détail d'une formation, le champ **« Informations pour les stagiaires »** affichait son texte brut. Quand il contenait une URL, celle-ci n'était pas cliquable.

## Changements

- Nouveau composant réutilisable `components/ui/Linkify.tsx` qui transforme les URLs d'un texte en liens cliquables.
- Utilisation dans `app/formation/[slug]/page.tsx`, en conservant le `whitespace-pre-wrap` (retours à la ligne préservés).

### Détails du comportement
- Schémas reconnus : `http://`, `https://` et `www.` (préfixé automatiquement en `https://`).
- Liens ouverts dans un nouvel onglet (`target="_blank"` + `rel="noopener noreferrer"`).
- La ponctuation finale collée à une URL (`.`, `,`, `)`…) est exclue du lien.
- **Sécurité** : seuls les schémas http(s)/www. sont acceptés, donc une saisie type `javascript:` n'est jamais transformée en lien.

### Limites assumées
- Une URL contenant des parenthèses internes (ex. `…/wiki/Alpinisme_(sport)`) verra sa parenthèse finale tronquée — compromis classique du linkify naïf, très improbable sur ce contenu.
- Les emails ne sont pas transformés en `mailto:` (non demandé ; le contact officiel passe déjà par `ObfuscatedEmail`).

## Tests

`components/ui/Linkify.test.tsx` — 7 tests Vitest, tous verts (URL https, préfixe www., ponctuation finale, multi-URLs, absence d'URL, garde-fou `javascript:`, préservation du texte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text containing URLs now automatically converts to clickable links that open in a new tab with appropriate security attributes.
  * URLs embedded in text are properly detected, including www-prefixed addresses and trailing punctuation handling.

* **Tests**
  * Added comprehensive test coverage for URL detection and link rendering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->