### PR TITLE
perf(cache): mettre en cache les lectures de formations pour endormir le compute Neon

### DIFF
--- a/app/api/__tests__/sync.test.ts
+++ b/app/api/__tests__/sync.test.ts
@@ -28,10 +28,7 @@ vi.mock('@/lib/logger', () => ({
   }
 }));
 
-// La route invalide le cache des formations après un sync réussi. Hors contexte
-// Next (en test), revalidateTag n'est pas disponible : on le mocke. unstable_cache
-// (utilisé par @/lib/cachedFormations, importé pour le tag) est neutralisé en
-// passthrough.
+// revalidateTag/unstable_cache ne tournent pas hors contexte Next → mock.
 vi.mock('next/cache', () => ({
   revalidateTag: vi.fn(),
   unstable_cache: (fn: unknown) => fn,
@@ -93,7 +90,6 @@ describe('GET /api/sync', () => {
     expect(data.success).toBe(true);
     expect(SyncService.synchronize).toHaveBeenCalled();
     expect(SyncService.pingHealthcheck).toHaveBeenCalledWith(true, expect.any(String));
-    // Le cache des lectures publiques doit être invalidé après un sync réussi
     expect(vi.mocked(revalidateTag)).toHaveBeenCalledWith('formations');
   });
 
@@ -146,7 +142,6 @@ describe('GET /api/sync', () => {
     expect(data.success).toBe(false);
     expect(SyncService.sendErrorReport).toHaveBeenCalledWith(error);
     expect(SyncService.pingHealthcheck).toHaveBeenCalledWith(false, 'Sync failed');
-    // Pas d'invalidation de cache si le sync a échoué
     expect(vi.mocked(revalidateTag)).not.toHaveBeenCalled();
   });
 });

--- a/app/api/__tests__/sync.test.ts
+++ b/app/api/__tests__/sync.test.ts
@@ -38,6 +38,7 @@ vi.mock('next/cache', () => ({
 }));
 
 import { SyncService } from '@/services/formation/sync.service';
+import { revalidateTag } from 'next/cache';
 
 describe('GET /api/sync', () => {
   beforeEach(() => {
@@ -92,6 +93,8 @@ describe('GET /api/sync', () => {
     expect(data.success).toBe(true);
     expect(SyncService.synchronize).toHaveBeenCalled();
     expect(SyncService.pingHealthcheck).toHaveBeenCalledWith(true, expect.any(String));
+    // Le cache des lectures publiques doit être invalidé après un sync réussi
+    expect(vi.mocked(revalidateTag)).toHaveBeenCalledWith('formations');
   });
 
   it('should send partial error report when sync has some errors', async () => {
@@ -143,5 +146,7 @@ describe('GET /api/sync', () => {
     expect(data.success).toBe(false);
     expect(SyncService.sendErrorReport).toHaveBeenCalledWith(error);
     expect(SyncService.pingHealthcheck).toHaveBeenCalledWith(false, 'Sync failed');
+    // Pas d'invalidation de cache si le sync a échoué
+    expect(vi.mocked(revalidateTag)).not.toHaveBeenCalled();
   });
 });

--- a/app/api/__tests__/sync.test.ts
+++ b/app/api/__tests__/sync.test.ts
@@ -28,6 +28,15 @@ vi.mock('@/lib/logger', () => ({
   }
 }));
 
+// La route invalide le cache des formations après un sync réussi. Hors contexte
+// Next (en test), revalidateTag n'est pas disponible : on le mocke. unstable_cache
+// (utilisé par @/lib/cachedFormations, importé pour le tag) est neutralisé en
+// passthrough.
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  unstable_cache: (fn: unknown) => fn,
+}));
+
 import { SyncService } from '@/services/formation/sync.service';
 
 describe('GET /api/sync', () => {

--- a/app/api/formations/route.ts
+++ b/app/api/formations/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { FormationService } from '@/services/formation/formations.service';
-import { FormationRepository } from '@/repositories/FormationRepository';
+import { getCachedFormations } from '@/lib/cachedFormations';
 import { logger } from '@/lib/logger';
 import {
   checkRateLimit,
@@ -8,9 +7,6 @@ import {
   rateLimitResponse,
   addRateLimitHeaders,
 } from '@/lib/rateLimit';
-
-const formationRepository = new FormationRepository();
-const formationService = new FormationService(formationRepository);
 
 // Rate limit: 60 requests per minute per IP
 const RATE_LIMIT_CONFIG = { limit: 60, windowSeconds: 60 };
@@ -26,7 +22,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const allFormations = await formationService.getAllFormations();
+    const allFormations = await getCachedFormations();
     const response = NextResponse.json(allFormations);
     return addRateLimitHeaders(response, rateLimitResult);
   } catch (error) {

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -1,5 +1,7 @@
 export const maxDuration = 60;
+import { revalidateTag } from 'next/cache';
 import { SyncService } from '@/services/formation/sync.service';
+import { FORMATIONS_CACHE_TAG } from '@/lib/cachedFormations';
 import { logger } from '@/lib/logger';
 import { validateCronSecret, unauthorizedResponse } from '@/lib/auth';
 
@@ -11,6 +13,13 @@ export async function GET(request: Request) {
 
   try {
     const syncResult = await SyncService.synchronize();
+
+    // Les données viennent d'être mises à jour : on invalide le cache des
+    // lectures publiques pour que le site reflète le sync en quelques minutes
+    // (sinon le cache 24h pourrait servir des données périmées jusqu'au
+    // prochain TTL). C'est ce qui permet de cacher agressivement sans dégrader
+    // la fraîcheur.
+    revalidateTag(FORMATIONS_CACHE_TAG);
 
     // Build report for healthcheck (visible in healthchecks.io dashboard)
     const status = syncResult.errors.length === 0 ? '✅' : '⚠️';

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -14,11 +14,7 @@ export async function GET(request: Request) {
   try {
     const syncResult = await SyncService.synchronize();
 
-    // Les données viennent d'être mises à jour : on invalide le cache des
-    // lectures publiques pour que le site reflète le sync en quelques minutes
-    // (sinon le cache 24h pourrait servir des données périmées jusqu'au
-    // prochain TTL). C'est ce qui permet de cacher agressivement sans dégrader
-    // la fraîcheur.
+    // Reflète le sync sans attendre le TTL du cache.
     revalidateTag(FORMATIONS_CACHE_TAG);
 
     // Build report for healthcheck (visible in healthchecks.io dashboard)

--- a/app/formation/[slug]/page.tsx
+++ b/app/formation/[slug]/page.tsx
@@ -1,9 +1,9 @@
+import { cache } from 'react';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { CalendarDays, MapPin, Users, Euro, User, Home, FileText, Clock } from 'lucide-react';
-import { FormationRepository } from '@/repositories/FormationRepository';
-import { FormationService } from '@/services/formation/formations.service';
+import { getCachedFormations, getCachedFormationByReference } from '@/lib/cachedFormations';
 import { Formation } from '@/types/formation';
 import { extractReferenceFromSlug, getFormationUrl } from '@/utils/slug';
 import { FormationStructuredData, BreadcrumbStructuredData } from '@/components/seo/StructuredData';
@@ -16,7 +16,10 @@ import Linkify from '@/components/ui/Linkify';
 import { formatDate, formatFullDateRange } from '@/utils/dateUtils';
 import { logger } from '@/lib/logger';
 
-export const dynamic = 'force-dynamic';
+// Les données ne changent qu'au sync quotidien (4h) : on rend la page en ISR
+// (générée à la demande puis mise en cache 24h) plutôt qu'en SSR à chaque
+// requête. Évite de réveiller la base à chaque crawl de bot.
+export const revalidate = 86400;
 
 interface PageProps {
   params: Promise<{
@@ -24,30 +27,23 @@ interface PageProps {
   }>;
 }
 
-async function getFormation(slug: string): Promise<Formation | null> {
+// `cache()` mutualise l'appel entre generateMetadata et le rendu de la page :
+// une seule requête en base par génération au lieu de deux.
+const getFormation = cache(async (slug: string): Promise<Formation | null> => {
   const reference = extractReferenceFromSlug(slug);
   if (!reference) {
     return null;
   }
 
-  const formationRepository = new FormationRepository();
-  const formationService = new FormationService(formationRepository);
-
   try {
-    const formation = await formationService.getFormationByReference(reference);
-
-    // Si la formation existe, on la retourne
-    // (on accepte tout slug tant que la référence est correcte)
-    if (formation) {
-      return formation;
-    }
-
-    return null;
+    // On accepte tout slug tant que la référence est correcte ; la lecture
+    // passe par le cache tagué `formations` (invalidé au sync).
+    return await getCachedFormationByReference(reference);
   } catch (error) {
     logger.error('Erreur lors de la récupération de la formation', error, { slug, reference });
     return null;
   }
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
@@ -97,13 +93,11 @@ export default async function FormationPage({ params }: PageProps) {
     { name: formation.titre },
   ];
 
-  // Récupérer des formations similaires
-  const formationRepository = new FormationRepository();
-  const formationService = new FormationService(formationRepository);
+  // Récupérer des formations similaires (depuis le cache partagé)
   let similarFormations: Formation[] = [];
 
   try {
-    const allFormations = await formationService.getAllFormations();
+    const allFormations = await getCachedFormations();
     similarFormations = allFormations
       .filter(f =>
         f.reference !== formation.reference &&

--- a/app/formation/[slug]/page.tsx
+++ b/app/formation/[slug]/page.tsx
@@ -16,9 +16,7 @@ import Linkify from '@/components/ui/Linkify';
 import { formatDate, formatFullDateRange } from '@/utils/dateUtils';
 import { logger } from '@/lib/logger';
 
-// Les données ne changent qu'au sync quotidien (4h) : on rend la page en ISR
-// (générée à la demande puis mise en cache 24h) plutôt qu'en SSR à chaque
-// requête. Évite de réveiller la base à chaque crawl de bot.
+// ISR : régénérée 1×/jour plutôt que rendue à chaque requête.
 export const revalidate = 86400;
 
 interface PageProps {
@@ -27,8 +25,7 @@ interface PageProps {
   }>;
 }
 
-// `cache()` mutualise l'appel entre generateMetadata et le rendu de la page :
-// une seule requête en base par génération au lieu de deux.
+// cache() : dédoublonne l'appel entre generateMetadata et la page.
 const getFormation = cache(async (slug: string): Promise<Formation | null> => {
   const reference = extractReferenceFromSlug(slug);
   if (!reference) {
@@ -36,8 +33,6 @@ const getFormation = cache(async (slug: string): Promise<Formation | null> => {
   }
 
   try {
-    // On accepte tout slug tant que la référence est correcte ; la lecture
-    // passe par le cache tagué `formations` (invalidé au sync).
     return await getCachedFormationByReference(reference);
   } catch (error) {
     logger.error('Erreur lors de la récupération de la formation', error, { slug, reference });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,13 @@
 import { MetadataRoute } from 'next';
-import { FormationRepository } from '@/repositories/FormationRepository';
-import { FormationService } from '@/services/formation/formations.service';
+import { getCachedFormations, getCachedDisciplines } from '@/lib/cachedFormations';
 import { generateFormationSlug } from '@/utils/slug';
 import { logger } from '@/lib/logger';
 
+// On garde le rendu dynamique (le sitemap n'est pas généré au build, ce qui
+// évite toute dépendance à la base au moment du build). Les requêtes passent
+// par le cache partagé : la base n'est donc touchée qu'une fois par jour, pas
+// à chaque crawl de bot.
 export const dynamic = 'force-dynamic';
-export const revalidate = 3600; // Revalidate every hour
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://formations.ffcam-aura.fr';
@@ -39,12 +41,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ];
 
   try {
-    // Récupérer dynamiquement toutes les formations
-    const formationRepository = new FormationRepository();
-    const formationService = new FormationService(formationRepository);
-
-    // Récupérer toutes les disciplines disponibles
-    const disciplines = await formationService.getAllDisciplines();
+    // Récupérer toutes les disciplines disponibles (cache partagé)
+    const disciplines = await getCachedDisciplines();
 
     const disciplinePages: MetadataRoute.Sitemap = disciplines.map(discipline => ({
       url: `${baseUrl}?discipline=${encodeURIComponent(discipline)}`,
@@ -54,7 +52,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }));
 
     // Récupérer toutes les formations pour créer les URLs individuelles
-    const formations = await formationService.getAllFormations();
+    const formations = await getCachedFormations();
 
     // Filtrer les formations futures uniquement
     const activeFormations = formations.filter(formation => {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,10 +3,8 @@ import { getCachedFormations, getCachedDisciplines } from '@/lib/cachedFormation
 import { generateFormationSlug } from '@/utils/slug';
 import { logger } from '@/lib/logger';
 
-// On garde le rendu dynamique (le sitemap n'est pas généré au build, ce qui
-// évite toute dépendance à la base au moment du build). Les requêtes passent
-// par le cache partagé : la base n'est donc touchée qu'une fois par jour, pas
-// à chaque crawl de bot.
+// force-dynamic : évite la dépendance DB au build. Les lectures passent par le
+// cache, donc DB touchée ~1×/jour (pas à chaque crawl).
 export const dynamic = 'force-dynamic';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/lib/cachedFormations.ts
+++ b/lib/cachedFormations.ts
@@ -1,0 +1,52 @@
+import { unstable_cache } from 'next/cache';
+import { FormationRepository } from '@/repositories/FormationRepository';
+import { FormationService } from '@/services/formation/formations.service';
+import { Formation } from '@/types/formation';
+
+/**
+ * Lectures publiques des formations, mises en cache.
+ *
+ * Les données ne changent qu'une fois par jour (sync planifié de 4h via
+ * /api/sync). Inutile donc d'interroger Postgres à chaque requête : on cache
+ * agressivement le résultat et on laisse la revalidation rafraîchir une fois
+ * par jour. Cela évite de réveiller le compute Neon à chaque visite / crawl de
+ * bot, qui était la cause d'une base active ~24/7.
+ *
+ * La fraîcheur reste alignée sur le sync : /api/sync appelle
+ * `revalidateTag(FORMATIONS_CACHE_TAG)` à la fin de chaque synchro, ce qui
+ * purge ces caches et fait refléter les nouvelles données en quelques minutes.
+ */
+export const FORMATIONS_CACHE_TAG = 'formations';
+
+const ONE_DAY_SECONDS = 86_400;
+
+const buildService = () => new FormationService(new FormationRepository());
+
+export const getCachedFormations = unstable_cache(
+  async (): Promise<Formation[]> => buildService().getAllFormations(),
+  ['formations:all'],
+  { revalidate: ONE_DAY_SECONDS, tags: [FORMATIONS_CACHE_TAG] }
+);
+
+export const getCachedDisciplines = unstable_cache(
+  async (): Promise<string[]> => buildService().getAllDisciplines(),
+  ['formations:disciplines'],
+  { revalidate: ONE_DAY_SECONDS, tags: [FORMATIONS_CACHE_TAG] }
+);
+
+/**
+ * Lecture d'une formation par référence, taguée explicitement `formations`.
+ *
+ * On inclut la référence dans la clé de cache pour avoir une entrée par
+ * formation. Le tag permet à `revalidateTag(FORMATIONS_CACHE_TAG)` (appelé
+ * après le sync) d'invalider aussi la page détail, sans dépendre du fait
+ * qu'elle lise par ailleurs `getCachedFormations()`.
+ */
+export const getCachedFormationByReference = (
+  reference: string
+): Promise<Formation | null> =>
+  unstable_cache(
+    () => buildService().getFormationByReference(reference),
+    ['formations:by-reference', reference],
+    { revalidate: ONE_DAY_SECONDS, tags: [FORMATIONS_CACHE_TAG] }
+  )();

--- a/lib/cachedFormations.ts
+++ b/lib/cachedFormations.ts
@@ -3,19 +3,8 @@ import { FormationRepository } from '@/repositories/FormationRepository';
 import { FormationService } from '@/services/formation/formations.service';
 import { Formation } from '@/types/formation';
 
-/**
- * Lectures publiques des formations, mises en cache.
- *
- * Les données ne changent qu'une fois par jour (sync planifié de 4h via
- * /api/sync). Inutile donc d'interroger Postgres à chaque requête : on cache
- * agressivement le résultat et on laisse la revalidation rafraîchir une fois
- * par jour. Cela évite de réveiller le compute Neon à chaque visite / crawl de
- * bot, qui était la cause d'une base active ~24/7.
- *
- * La fraîcheur reste alignée sur le sync : /api/sync appelle
- * `revalidateTag(FORMATIONS_CACHE_TAG)` à la fin de chaque synchro, ce qui
- * purge ces caches et fait refléter les nouvelles données en quelques minutes.
- */
+// Lectures de formations en cache (données rafraîchies 1×/jour par le sync).
+// Invalidées via revalidateTag(FORMATIONS_CACHE_TAG) dans /api/sync.
 export const FORMATIONS_CACHE_TAG = 'formations';
 
 const ONE_DAY_SECONDS = 86_400;
@@ -34,14 +23,7 @@ export const getCachedDisciplines = unstable_cache(
   { revalidate: ONE_DAY_SECONDS, tags: [FORMATIONS_CACHE_TAG] }
 );
 
-/**
- * Lecture d'une formation par référence, taguée explicitement `formations`.
- *
- * On inclut la référence dans la clé de cache pour avoir une entrée par
- * formation. Le tag permet à `revalidateTag(FORMATIONS_CACHE_TAG)` (appelé
- * après le sync) d'invalider aussi la page détail, sans dépendre du fait
- * qu'elle lise par ailleurs `getCachedFormations()`.
- */
+// reference dans la clé → une entrée de cache par formation.
 export const getCachedFormationByReference = (
   reference: string
 ): Promise<Formation | null> =>


### PR DESCRIPTION
## Contexte

Enquête partie d'une facture Neon inattendue (~70 $/mois sur l'ensemble des projets). Le plus gros poste de compute restant venait de **cette base** : elle était active **~24/7**.

Diagnostic (journal d'opérations Neon + `pg_stat_activity`) : la base était réveillée toutes les 5-15 min, **jour et nuit, de façon régulière** — donc par un process automatique, pas par du trafic humain. Cause : les **bots qui crawlent le catalogue** via le sitemap, sur des pages qui interrogeaient Postgres **à chaque requête**.

L'historique git confirme qu'aucun de ces réglages n'était un choix « temps réel » assumé : `force-dynamic` sur la page formation posé sans justification, sur le sitemap pour contourner une erreur de build. Or les données ne changent qu'**une fois par jour** (sync de 4h) → tout est cachable.

## Changements

- **`lib/cachedFormations.ts`** (nouveau) : accesseurs `unstable_cache` partagés et tagués `formations` (TTL 24h) pour `getAllFormations`, `getAllDisciplines` et `getFormationByReference`.
- **`app/formation/[slug]/page.tsx`** : `force-dynamic` → **ISR `revalidate=86400`** + `React.cache()` (mutualise la requête entre `generateMetadata` et le rendu). La lecture principale passe par l'accesseur tagué, donc sa fraîcheur ne dépend pas du bloc « formations similaires ».
- **`app/api/formations/route.ts`** et **`app/sitemap.ts`** : lectures servies depuis le cache (le sitemap reste `force-dynamic` → **aucune dépendance DB au build**).
- **`app/api/sync/route.ts`** : `revalidateTag('formations')` à la fin de chaque sync → le site reflète les nouvelles données **en quelques minutes**, pas au bout du TTL.

## Effet attendu

La base n'est plus réveillée à chaque visite/crawl mais **~1×/jour**. Le compute de cette base devrait s'effondrer (de ~215 CU-h/mois vers quasi rien).

## Fraîcheur

Inchangée pour l'utilisateur : la donnée était déjà rafraîchie une fois par jour (sync 4h). L'invalidation par tag au sync garantit que les nouveautés apparaissent rapidement.

## Vérifications

- ✅ `pnpm build` — build complet, aucune route DB-dépendante prérendue au build
- ✅ `tsc --noEmit` — propre sur les fichiers touchés
- ✅ `pnpm test` — 115 tests passés (mock `next/cache` ajouté pour les tests de `/api/sync`)
- ✅ lint pre-commit

## À valider après déploiement

- `curl -sI .../formation/<slug>` deux fois → `x-nextjs-cache: HIT` au 2ᵉ appel (confirme l'ISR).
- Re-vérifier l'usage compute Neon ~48h après le déploiement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added mock support for cache operations and assertions to verify cache invalidation in API tests

* **New Features**
  * Shared caching for formation and discipline data with tag-based invalidation
  * Formation pages now use ISR (1-day revalidation) for faster responses

* **Refactor**
  * APIs, sync endpoint, formation pages and sitemap now read from the shared cache; sync explicitly clears related cached reads
  * Sitemap generation runs at runtime rather than relying on time-based ISR
<!-- end of auto-generated comment: release notes by coderabbit.ai -->